### PR TITLE
Ajuste da Versão phpmailer de 5.2 para 6.9.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php" : ">= 5.6",
-        "phpmailer/phpmailer": "^5.2",
+        "phpmailer/phpmailer": "^6.9.2",
         "soundasleep/html2text": "~0.3"
     },
     "require-dev": {


### PR DESCRIPTION
Ultima versão atualmente em 30/10/2024 para envio de email usando Oauth